### PR TITLE
plugin dependency update

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
 
     <!-- ios -->
     <platform name="ios">
-        <dependency id="de.appplant.cordova.common.registerusernotificationsettings" />
+        <dependency id="cordova-plugin-app-event" />
         <config-file target="config.xml" parent="/*">
             <feature name="LocalNotification">
                 <param name="ios-package" value="APPLocalNotification" onload="true" />

--- a/src/ios/APPAppEventDelegate.h
+++ b/src/ios/APPAppEventDelegate.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2013-2016 appPlant UG
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+@protocol APPAppEventDelegate
+
+/*
+ By implementing the interface the plugin indicates interest
+ to receive app events.
+ */
+
+@end

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -25,7 +25,7 @@
 #import "APPLocalNotificationOptions.h"
 #import "UIApplication+APPLocalNotification.h"
 #import "UILocalNotification+APPLocalNotification.h"
-#import "AppDelegate+APPRegisterUserNotificationSettings.h"
+#import "AppDelegate+APPAppEvent.h"
 
 @interface APPLocalNotification ()
 

--- a/src/ios/AppDelegate.APPAppEvent.h
+++ b/src/ios/AppDelegate.APPAppEvent.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2013-2016 by appPlant UG. All rights reserved.
+ *
+ * @APPPLANT_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apache License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://opensource.org/licenses/Apache-2.0/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPPLANT_LICENSE_HEADER_END@
+ */
+
+#import "AppDelegate.h"
+
+extern NSString* const UIApplicationRegisterUserNotificationSettings;
+
+@interface AppDelegate (APPAppEvent)
+
+@end

--- a/src/ios/AppDelegate.APPAppEvent.m
+++ b/src/ios/AppDelegate.APPAppEvent.m
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2013-2016 by appPlant UG. All rights reserved.
+ *
+ * @APPPLANT_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apache License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://opensource.org/licenses/Apache-2.0/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPPLANT_LICENSE_HEADER_END@
+ */
+
+#import "AppDelegate+APPAppEvent.h"
+#import <Availability.h>
+#import <objc/runtime.h>
+
+NSString* const UIApplicationRegisterUserNotificationSettings = @"UIApplicationRegisterUserNotificationSettings";
+
+@implementation AppDelegate (APPAppEvent)
+
+#pragma mark -
+#pragma mark Life Cycle
+
+/**
+ * Its dangerous to override a method from within a category.
+ * Instead we will use method swizzling.
+ */
++ (void) load
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+    [self exchange_methods:@selector(application:didRegisterUserNotificationSettings:)
+                  swizzled:@selector(swizzled_application:didRegisterUserNotificationSettings:)];
+#endif
+
+#if CORDOVA_VERSION_MIN_REQUIRED >= 40000
+    [self exchange_methods:@selector(application:didReceiveLocalNotification:)
+                  swizzled:@selector(swizzled_application:didReceiveLocalNotification:)];
+#endif
+}
+
+#pragma mark -
+#pragma mark Delegate
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+/**
+ * Tells the delegate what types of notifications may be used
+ * to get the user’s attention.
+ */
+- (void)           swizzled_application:(UIApplication*)application
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)settings
+{
+    // re-post (broadcast)
+    [self postNotificationName:UIApplicationRegisterUserNotificationSettings object:settings];
+    // This actually calls the original method over in AppDelegate
+    [self swizzled_application:application didRegisterUserNotificationSettings:settings];
+}
+#endif
+
+#if CORDOVA_VERSION_MIN_REQUIRED >= 40000
+/**
+ * Repost all local notification using the default NSNotificationCenter so
+ * multiple plugins may respond.
+ */
+- (void)   swizzled_application:(UIApplication*)application
+    didReceiveLocalNotification:(UILocalNotification*)notification
+{
+    // re-post (broadcast)
+    [self postNotificationName:CDVLocalNotification object:notification];
+    // This actually calls the original method over in AppDelegate
+    [self swizzled_application:application didReceiveLocalNotification:notification];
+}
+#endif
+
+#pragma mark -
+#pragma mark Core
+
+/**
+ * Exchange the method implementations.
+ */
++ (void) exchange_methods:(SEL)original swizzled:(SEL)swizzled
+{
+    class_addMethod(self, original, (IMP) defaultMethodIMP, "v@:");
+
+    Method original_method = class_getInstanceMethod(self, original);
+    Method swizzled_method = class_getInstanceMethod(self, swizzled);
+
+    method_exchangeImplementations(original_method, swizzled_method);
+}
+
+#pragma mark -
+#pragma mark Helper
+
+void defaultMethodIMP (id self, SEL _cmd) { /* nothing to do here */ }
+
+/**
+ * Broadcasts the notification to all listeners.
+ */
+- (void) postNotificationName:(NSString*)aName object:(id)anObject
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:aName
+                                                        object:anObject];
+}
+
+@end

--- a/src/ios/CDVPlugin.APPAppEvent.h
+++ b/src/ios/CDVPlugin.APPAppEvent.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2013-2016 by appPlant UG. All rights reserved.
+ *
+ * @APPPLANT_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apache License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://opensource.org/licenses/Apache-2.0/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPPLANT_LICENSE_HEADER_END@
+ */
+
+#import "Cordova/CDVPlugin.h"
+
+@interface CDVPlugin (APPAppEvent)
+
+@end

--- a/src/ios/CDVPlugin.APPAppEvent.m
+++ b/src/ios/CDVPlugin.APPAppEvent.m
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2013-2016 by appPlant UG. All rights reserved.
+ *
+ * @APPPLANT_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apache License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://opensource.org/licenses/Apache-2.0/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPPLANT_LICENSE_HEADER_END@
+ */
+
+#import "APPAppEventDelegate.h"
+#import "CDVPlugin+APPAppEvent.h"
+#import "AppDelegate+APPAppEvent.h"
+
+#import <objc/runtime.h>
+
+@implementation CDVPlugin (APPAppEvent)
+
+static IMP orig_pluginInitialize;
+
+#pragma mark -
+#pragma mark Life Cycle
+
+/**
+ * Its dangerous to override a method from within a category.
+ * Instead we will use method swizzling.
+ */
++ (void) initialize
+{
+    // To keep compatibility with local-notifiations v0.8.4
+    if ([NSStringFromClass(self) isEqualToString:@"APPLocalNotification"]
+        || [self conformsToProtocol:@protocol(APPAppEventDelegate)]) {
+
+        orig_pluginInitialize = [self exchange_init_methods];
+    }
+}
+
+#pragma mark -
+#pragma mark Delegate
+
+/**
+ * Registers obervers after plugin was initialized.
+ */
+void swizzled_pluginInitialize(id self, SEL _cmd)
+{
+    if (orig_pluginInitialize != NULL) {
+        ((void(*)(id, SEL))orig_pluginInitialize)(self, _cmd);
+        orig_pluginInitialize = NULL;
+    }
+
+    [self addObserver:NSSelectorFromString(@"didReceiveLocalNotification:")
+                 name:CDVLocalNotification
+               object:NULL];
+
+    [self addObserver:NSSelectorFromString(@"didFinishLaunchingWithOptions:")
+                 name:UIApplicationDidFinishLaunchingNotification
+               object:NULL];
+
+    [self addObserver:NSSelectorFromString(@"didRegisterUserNotificationSettings:")
+                 name:UIApplicationRegisterUserNotificationSettings
+               object:NULL];
+}
+
+#pragma mark -
+#pragma mark Core
+
+/**
+ * Exchange the method implementations for pluginInitialize
+ * and return the original implementation.
+ */
++ (IMP) exchange_init_methods
+{
+    IMP swizzleImp = (IMP) swizzled_pluginInitialize;
+    Method origImp = class_getInstanceMethod(self, @selector(pluginInitialize));
+
+    if (method_getImplementation(origImp) != swizzleImp) {
+        return method_setImplementation(origImp, swizzleImp);
+    }
+
+    return NULL;
+}
+
+/**
+ * Register an observer if the caller responds to it.
+ */
+- (void) addObserver:(SEL)selector
+                name:(NSString*)event
+              object:(id)object
+{
+    if (![self respondsToSelector:selector])
+        return;
+
+    NSNotificationCenter* center = [NSNotificationCenter
+                                    defaultCenter];
+
+    [center addObserver:self
+               selector:selector
+                   name:event
+                 object:object];
+}
+
+@end


### PR DESCRIPTION
the de.appplant.cordova.common.registerusernotificationsettings plugin is deprecated and not available on the repo. Replace by https://github.com/katzer/cordova-plugin-app-event
